### PR TITLE
Async downloads + more

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -44,9 +44,7 @@ func getAlbumInfo(rawContents io.Reader) (modelName string, albumName string) {
 	title := getTitle(rawContents)
 	s := strings.Split(title, " Photo Album: ")
 	ss := strings.Split(s[1], " | SuicideGirls")
-	modelName = s[0]
-	albumName = ss[0]
-	return
+	return strings.TrimSpace(s[0]), strings.TrimSpace(ss[0])
 }
 
 func getTitle(rawContents io.Reader) string {

--- a/crawler.go
+++ b/crawler.go
@@ -14,7 +14,7 @@ import (
 
 func crawlImages(rawContents io.Reader) []string {
 	z := html.NewTokenizer(rawContents)
-	imagesFound := []string{}
+	imagesFound := make([]string, 0)
 
 	for {
 		tt := z.Next()

--- a/crawler.go
+++ b/crawler.go
@@ -73,7 +73,7 @@ func getContents(link string) io.Reader {
 	jar, _ := cookiejar.New(nil)
 	var cookies []*http.Cookie
 	cookie := &http.Cookie{
-		Name:   "sessionid",
+		Name:   "sessid",
 		Value:  sessionId,
 		Path:   "/",
 		Domain: "www.suicidegirls.com",

--- a/crawler.go
+++ b/crawler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -9,8 +8,6 @@ import (
 	"strings"
 
 	"golang.org/x/net/html"
-	"bufio"
-	"os"
 )
 
 func crawlImages(rawContents io.Reader) []string {
@@ -93,23 +90,6 @@ func getContents(link string) io.Reader {
 
 	req, _ := http.NewRequest("GET", link, nil)
 	resp, err := client.Do(req)
-
-	checkSessionId := sessionId
-	for _, c := range resp.Cookies() {
-		if c.Name == "sessionid" {
-			checkSessionId = c.Value
-		}
-	}
-
-	if len(checkSessionId) < 100 {
-		fmt.Println("Session expired, enter new SessionID: ")
-		reader := bufio.NewReader(os.Stdin)
-		newSessionId, _ := reader.ReadString('\n')
-		settings[settingsSessionId] = newSessionId[:len(newSessionId)-1]
-		return getContents(link)
-	} else {
-		settings[settingsSessionId] = checkSessionId
-	}
 
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/TomK/SGo-Scraper
+
+go 1.16
+
+require (
+	github.com/joho/godotenv v1.3.0
+	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 h1:qPnAdmjNA41t3QBTx2mFGf/SD1IoslhYu7AmdsVzCcs=
+golang.org/x/net v0.0.0-20190926025831-c00fd9afed17/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -19,7 +19,10 @@ const (
 )
 
 var (
-	settings map[string]string
+	settings        map[string]string
+	scanner         *bufio.Scanner
+	finalizeWithZip bool
+	configPath      string
 )
 
 func main() {
@@ -28,7 +31,7 @@ func main() {
 		settingsDownloadsKey: "downloads",
 		settingsSessionId:    "",
 	}
-	scanner := bufio.NewScanner(os.Stdin)
+	scanner = bufio.NewScanner(os.Stdin)
 
 	// get application dir
 	usr, err := user.Current()
@@ -36,7 +39,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	configPath := usr.HomeDir + "/.SGo-Scraper"
+	configPath = usr.HomeDir + "/.SGo-Scraper"
 
 	if _, err := os.Stat(configPath); err == nil {
 		settings, err = godotenv.Read(configPath)
@@ -45,9 +48,15 @@ func main() {
 		}
 	}
 
-	finalizeWithZip := flag.Bool("zip", false, "zip")
+	finalizeWithZip = *flag.Bool("zip", false, "zip")
 	flag.Parse()
 
+	for {
+		getUrl()
+	}
+}
+
+func getUrl() {
 	fmt.Print("Please enter album URL: ")
 	scanner.Scan()
 	albumURL := scanner.Text()
@@ -91,7 +100,7 @@ func main() {
 
 	wg.Wait()
 
-	if *finalizeWithZip {
+	if finalizeWithZip {
 		err := ZipFiles(albumDir+"/"+albumName+".zip", imagesDownloaded)
 		if err != nil {
 			panic(err)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	checkAndCreateDir(downloadsDir)
 	checkAndCreateDir(albumDir)
-	imagesDownloaded := []string{}
+	imagesDownloaded := make([]string, 0)
 
 	for i, imageURL := range imagesFound {
 		imageOutput := albumDir + "/" + leftPad(strconv.Itoa(i), "0", digitsLen(len(imagesFound))-1) + ".jpg"

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
+	"fmt"
 )
 
 func checkAndCreateDir(path string) {
@@ -20,7 +20,7 @@ func digitsLen(n int) int {
 }
 
 func leftPad(s string, padStr string, pLen int) string {
-	return strings.Repeat(padStr, pLen) + s
+	return fmt.Sprintf("%"+padStr+strconv.Itoa(pLen)+"s", s)
 }
 
 func saveImage(url string, output string) (int64, error) {

--- a/utils.go
+++ b/utils.go
@@ -24,8 +24,16 @@ func leftPad(s string, padStr string, pLen int) string {
 }
 
 func saveImage(url string, output string) (int64, error) {
-	img, _ := os.Create(output)
-	resp, _ := http.Get(url)
+	img, err := os.Create(output)
+	if err != nil {
+		return 0, err
+	}
+	defer img.Close()
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
 	return io.Copy(img, resp.Body)
 }
 
@@ -46,6 +54,7 @@ func ZipFiles(filename string, files []string) error {
 		if err != nil {
 			return err
 		}
+		//noinspection GoDeferInLoop
 		defer zipfile.Close()
 
 		info, err := zipfile.Stat()


### PR DESCRIPTION
This is a PR of my complete fork.  It includes:
 - async downloads
 - persistent storage of settings (download dir and sessionId) (USER_HOME/.SGo-Scraper)
 - prompt for url instead of passed as argument
 - request for new sessionId if no images found (the usual cause of no images is an expired sessionId)
 - consistent filename padding
 - improved output showing download progress per image