### PR TITLE
Changed the name of the "sessionid" cookie value to "sessid" (Issue #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to also compress the downloaded files, append `-z` at the end as arg
 1. Using Google Chrome, log in into your Suicide Girls account.
 2. Pop out the developers console and go to _Application_ tab.
 3. At the left, go to Storage -> Cookies -> https://suicidegirls.com
-4. Scroll down until you find _sessionid_ cookie.
+4. Scroll down until you find _sessid_ cookie.
 5. Copy the value from _Value_ column.
 
 ##### Why this is needed?

--- a/crawler.go
+++ b/crawler.go
@@ -77,7 +77,7 @@ func getContents(link string) io.Reader {
 	jar, _ := cookiejar.New(nil)
 	var cookies []*http.Cookie
 	cookie := &http.Cookie{
-		Name:   "sessionid",
+		Name:   "sessid",
 		Value:  sessionidCookie,
 		Path:   "/",
 		Domain: "www.suicidegirls.com",


### PR DESCRIPTION
Changed the name of the "sessionid" cookie value to "sessid", to align with the current implementation of the SG site. I believe this addresses Issue #4 .